### PR TITLE
initial appveyor.yml CI config

### DIFF
--- a/Remove dup lines/Remove dup lines/DllExport/DllExportAttribute.cs
+++ b/Remove dup lines/Remove dup lines/DllExport/DllExportAttribute.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿// NPP plugin platform for .Net v0.94.00 by Kasper B. Graversen etc.
+using System;
 using System.Runtime.InteropServices;
 
 namespace NppPlugin.DllExport
@@ -9,26 +10,20 @@ namespace NppPlugin.DllExport
         public DllExportAttribute()
         {
         }
+
         public DllExportAttribute(string exportName)
             : this(exportName, CallingConvention.StdCall)
         {
         }
+
         public DllExportAttribute(string exportName, CallingConvention callingConvention)
         {
             ExportName = exportName;
             CallingConvention = callingConvention;
         }
-        CallingConvention _callingConvention;
-        public CallingConvention CallingConvention
-        {
-            get { return _callingConvention; }
-            set { _callingConvention = value; }
-        }
-        string _exportName;
-        public string ExportName
-        {
-            get { return _exportName; }
-            set { _exportName = value; }
-        }
+
+        public CallingConvention CallingConvention { get; set; }
+
+        public string ExportName { get; set; }
     }
 }

--- a/Remove dup lines/Remove dup lines/DllExport/NppPlugin.DllExport.targets
+++ b/Remove dup lines/Remove dup lines/DllExport/NppPlugin.DllExport.targets
@@ -5,6 +5,11 @@
   <Target Name="AfterBuild"
           DependsOnTargets="GetFrameworkPaths"
           >
+    <PropertyGroup>
+		<!-- LibToolPath is optional - it's needed to debug C++, but you can still debug the C# code without it
+			If you don't have the C++ toolchain installed this is missing, but then you can't' debug C++ anyway -->
+        <LibToolPath Condition="Exists('$(DevEnvDir)\..\..\VC\bin')">$(DevEnvDir)\..\..\VC\bin</LibToolPath>
+    </PropertyGroup>
     <DllExportTask Platform="$(Platform)"
                    PlatformTarget="$(PlatformTarget)"
                    CpuType="$(CpuType)"
@@ -17,8 +22,25 @@
                    ProjectDirectory="$(MSBuildProjectDirectory)"
                    InputFileName="$(TargetPath)"
                    FrameworkPath="$(TargetedFrameworkDir);$(TargetFrameworkDirectory)"
-                   LibToolPath="$(DevEnvDir)\..\..\VC\bin"
+                   LibToolPath="$(LibToolPath)"
                    LibToolDllPath="$(DevEnvDir)"
-                   SdkPath="$(FrameworkSDKDir)"/>
+                   SdkPath="$(SDK40ToolsPath)"/>
+ 
+	<!-- $(MSBuildProgramFiles32) points to the 32 bit program files dir.
+		On 32 bit windows usually C:\Program Files\
+		On 64 bit windows usually C:\Program Files (x86)\
+		$(ProgramW6432) points to the 64bit Program Files (on 32 bit windows it is blank) -->
+    <MakeDir Directories="$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\" Condition="Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\') AND !Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x86'" />
+    <Copy 
+        SourceFiles="$(TargetPath)" 
+        DestinationFolder="$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\" 
+        Condition="Exists('$(MSBuildProgramFiles32)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x86'"
+        ContinueOnError="false" />
+    <MakeDir Directories="$(ProgramW6432)\Notepad++\plugins\$(TargetName)\" Condition="Exists('$(ProgramW6432)\Notepad++\plugins\') AND !Exists('$(ProgramW6432)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x64'" />
+    <Copy 
+        SourceFiles="$(TargetPath)" 
+        DestinationFolder="$(ProgramW6432)\Notepad++\plugins\$(TargetName)\" 
+        Condition="Exists('$(ProgramW6432)\Notepad++\plugins\$(TargetName)\') AND '$(Platform)'=='x64'"
+        ContinueOnError="false" />
   </Target>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,63 @@
+version: 1.0.0.{build}
+image: Visual Studio 2017
+
+
+platform:
+    - Any CPU
+    #- x64
+
+configuration:
+    - Debug
+    - Release
+
+install:
+    - if "%platform%"=="x64" set archi=amd64
+    - if "%platform%"=="x64" set platform_input=x64
+
+    - if "%platform%"=="Any CPU" set archi=x86
+    - if "%platform%"=="Any CPU" set platform_input=Any CPU
+
+    - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\"Remove dup lines"
+    - msbuild "Remove dup lines.sln" /m /p:configuration="%configuration%" /p:platform="%platform_input%"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"\"Remove dup lines"
+    - ps: >-
+
+        if ($env:PLATFORM_INPUT -eq "x64") {
+            Push-AppveyorArtifact "bin\$($env:PLATFORM_INPUT)\$($env:CONFIGURATION)\Remove dup lines.dll" -FileName Remove dup lines.dll
+        }
+
+        if ($env:PLATFORM_INPUT -eq "AnyCPU" ) {
+            Push-AppveyorArtifact "bin\$($env:CONFIGURATION)\Remove dup lines.dll" -FileName Remove dup lines.dll
+        }
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release") {
+            if($env:PLATFORM_INPUT -eq "x64"){
+                $ZipFileName = "NppHash_$($env:APPVEYOR_REPO_TAG_NAME)_x64.zip"
+                7z a $ZipFileName bin\$env:PLATFORM_INPUT\$env:CONFIGURATION\Remove dup lines.dll
+            }
+            if($env:PLATFORM_INPUT -eq "AnyCPU"){
+                $ZipFileName = "NppHash_$($env:APPVEYOR_REPO_TAG_NAME)_x86.zip"
+                7z a $ZipFileName bin\$env:CONFIGURATION\Remove dup lines.dll
+            }
+        }
+
+artifacts:
+  - path: Remove_dup_lines_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        configuration: Release


### PR DESCRIPTION
See https://ci.appveyor.com/project/chcg/remove-dup-lines/builds/24750134.
You need to register your project at https://www.appveyor.com/, if you want to build your repo automatically.

Used VS2017 to build.
Partly updated with data from https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net. 
Not x64 ready yet.